### PR TITLE
Add GitHub workflow to auto-deploy site

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,55 @@
+# Builds and deploys the site if the build was successful
+name: Build & Deploy Site
+
+# Conditions necessary to trigger a build
+on:
+  push:
+    # Ignore pushes on all branches by default
+    # branches that should trigger a build must be explicitly excluded from the ignore using '!BRANCH_NAME'
+    branches-ignore:
+      - '**'
+      - '!master'
+
+    # Only build if a file in one of these paths has been changed
+    paths:
+      - 'src/main/asciidoc/**'
+      - 'src/main/template/**'
+
+jobs:
+  build:
+    name: Build & Deploy Site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Build Site
+        run: mvn clean compile
+
+      # Determines the short sha of the commit that triggered the build
+      - name: Determine Short SHA
+        if: success()
+        id: short-sha
+        run: |
+          short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
+          echo "::set-output name=short_sha::$short_sha"
+        shell: 'bash'
+
+      # Copies the build artifacts to 'docs/'
+      - name: Deploy Site
+        if: success()
+        run: cp -r target/site* docs/
+
+      # Commits any changes to the 'docs/' directory using the credentials of the commit that triggered the action
+      # Uses the GitHub action https://github.com/marketplace/actions/add-commit
+      - name: Commit Result
+        if: success()
+        uses: EndBug/add-and-commit@v4
+        with:
+          add: 'docs/'
+          message: 'Auto-deploy site for commit ${{ steps.short-sha.outputs.short_sha }}'
+        env:
+          # This is necessary in order to push a commit to the repo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged

--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ How to build the website:
  * Use `git branch MyBranchName` and `git checkout MyBranchName` to create a branch and check it out.
  * Adapt the asciidoc files in `src/main/asciidoc` or the website menu in  `src/main/template`
  * Call `mvn clean compile`. This generates html files in `target/site`. 
- * Copy all files from `target/site` into the `docs` folder, do not forget subfolders.
  * Verify the generated website by viewing it locally with a web browser. 
  * Commit changes with `git commit -m 'my commit message' `.
  * Push changes to the repository with `git push`.
  * Go to Github.com and create a PR for your branch
- * Once the PR is accepted, the changes should be visible on the website (you may have to refresh the browser). 
+ * Once the PR is accepted, the changes should be visible on the website (you may have to refresh the browser).
 
 How to add javadoc
 * Create the javadoc jar (e.g. jdo-api-3.2-javadoc.jar) in the db-jdo repository by calling `mvn clean install -Papache-release` in the api submodule.


### PR DESCRIPTION
Adds a GitHub workflow to auto-deploy the site if any of its sources
have changed and the build was successful.

The action is only run if
- the correct branches are pushed (currently only `master`)
AND
- at least one file in the correct paths was modified (currently
  `src/main/asciidoc/**` and `src/main/template/**`).

If the build was successful, the action copies the build results from
'`target/site/*` to `docs/` and creates a new commit with all changed
files in `docs/`. This commit is automatically pushed to the branch that
triggered the GitHub action. The new commit is attributed to the author
of the latest commit on that branch.

Removed the note to move the build results into the `docs/` folder when
creating a commit from the README as this is now done automatically.