### PR TITLE
Move site to separate branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,15 +1,3 @@
-# Staging and publishing profile for Apache JDO
-# NOTE: This does currently not work, presumably because JDO is a sub project and there is 
-#       no staging area for subprojects or for the parent 'db' project.
-staging:
-  profile: ~
-  whoami:  staging
-  subdir: content/jdo
- 
-publish:
-  whoami:  master
-  subdir:  content/jdo
-
 github:
   description: "Apache JDO project"
   homepage: https://db.apache.org/jdo

--- a/.asf.yaml.publish
+++ b/.asf.yaml.publish
@@ -1,0 +1,6 @@
+# Publishing profile for Apache JDO website
+#
+# This file is only used on the site publishing branch
+publish:
+  whoami:  publish
+  subdir:  jdo

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,18 +5,18 @@ name: Build & Deploy Site
 on:
   push:
     # Ignore pushes on all branches by default
-    # branches that should trigger a build must be explicitly excluded from the ignore using '!BRANCH_NAME'
+    # Branches that should trigger a build must be explicitly excluded from the ignore using '!BRANCH_NAME'
+    #
+    # Excluding the branch that is pushed by this action will lead to an infinite loop
     branches-ignore:
       - '**'
       - '!master'
 
     # Only build if a file in one of these paths has been changed
-    #
-    # This list must not contains directories which are modified and commited as part of this action
-    # Such a setup would lead to an infinite loop where the push as part of the action triggers a new run of the action
     paths:
       - 'src/main/asciidoc/**'
       - 'src/main/template/**'
+      - '.asf.yaml.publish'
 
 jobs:
   build:
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 1
 
       - name: Build Site
-        run: mvn clean install
+        run: mvn clean compile
 
       # Determines the short sha of the commit that triggered the build
       - name: Determine Short SHA
@@ -40,34 +40,49 @@ jobs:
           echo "::set-output name=short_sha::$short_sha"
         shell: 'bash'
 
-      # Determine the author data of the HEAD commit which will be used for the deploy commit
-      - name: Determine HEAD Author Data
+      # Determines the author data of the HEAD commit
+      # Sets up the author data to be used for the site deploy commit
+      - name: Determine HEAD Commit Author Data
         if: success()
         id: author-data
         run: |
+          echo "Reading author data"
           author_name=$(git log -1 --format='%aN' HEAD)
-          echo "::set-output name=author_name::$author_name"
           author_email=$(git log -1 --format='%aE' HEAD)
-          echo "::set-output name=author_email::$author_email"
+
+          echo "Setting up author data to use for deploy commit"
+          git config user.name $author_name
+          git config user.email $author_email
         shell: 'bash'
 
-      # Commits any changes to the 'docs/' directory using the credentials of the current HEAD commit; does nothing if there is nothing to commit
-      - name: Commit Result
+      # Publishes the site build results to a separate orphan branch
+      #
+      # Creates and checks out a new orphan branch
+      # Creates a single commit containing only the site build artifacts and site configuration files located in the root directory
+      # The commit is created with the author data set up in the previous step
+      # Force-pushes the created branch, overwriting the previously published site build
+      - name: Publish site branch
         if: success()
         run: |
-          echo "Adding changes"
-          git add 'docs/'
-          if $(git diff -s --cached --exit-code)
-            then
-              # nothing staged
-              echo "Nothing to commit"
-              exit 0
-          fi
-          echo "Setting up author data"
-          git config user.name "${{ steps.author-data.outputs.author_name }}"
-          git config user.email "${{ steps.author-data.outputs.author_email }}"
-          echo "Commiting changes"
+          branch_name="publish"
+
+          echo "Creating orphan branch"
+          git checkout --orphan $branch_name
+          echo
+
+          echo "Dropping content other than site data"
+          git reset
+          rm .gitignore
+          git add .asf.yaml.publish target/site
+          git clean -df
+          git mv target/site/* ./
+          git mv .asf.yaml.publish .asf.yaml
+          echo
+
+          echo "Committing changes"
           git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.short_sha }}"
-          echo "Pushing changes"
-          git push
+          echo
+
+          echo "Pushing site branch"
+          git push -f origin $branch_name
         shell: 'bash'

--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,0 @@
-RewriteEngine On
-RewriteBase /jdo/
-RewriteRule ^(?!docs/)(.*)$ docs/$1


### PR DESCRIPTION
Adjusts the site deployment job to instead deploy the site to a separate branch. This has the advantage that the build artifacts no longer have to be kept as part of the master branch. Instead, they are pushed to the orphan branch `publish`.

The separate branch `publish` only contains the site build artifacts and the site configuration files (`.asf.yaml`). All these resources are located directly in the root directory. The site branch will be completely overwritten when a new build is deployed, so only the latest build artifacts will be stored.

Moves the site publishing configuration to the separate file `.asf.yaml.publish`. This file is renamed to `.asf.yaml` as part of the creation of the deploy commit. This separates the site deployment configuration from the rest of the configuration done in `.asf.yaml`.

Removes the `.htaccess` file as a URL redirection should no longer be necessary as far as I can tell now that the resources are hosted in the root directory.

The result of this new build process can be observed in my fork: The [`publish` branch](https://github.com/tobous/db-jdo-site/tree/publish) was created by this [action run](https://github.com/tobous/db-jdo-site/runs/1709000835), resulting in these [GitHub pages](https://tobous.github.io/db-jdo-site/) displaying the `publish` branch.

As I am not that familiar with the site deployment infrastructure on the Apache side (especially the correct `.asf.yaml` and `.htaccess` configuration), it would be best to have somebody who is familiar with the topic have a look at it before merging. My changes are based on [this wiki entry](https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features).

### Things to do after (or when) merging this PR

As this PR changes the site deployment mechanisms, you will have to adjust the GitHub configuration to also deploy the site as GitHub pages. You can simply change the branch to deploy to the site branch (`publish`). The resources are located in the root directory, so no further configuration should be necessary.

Additionally, as the site deployment is now dependent on a separate branch, I would suggest setting up branch protection for the site branch to avoid it being accidentally deleted. This can be done in the repo settings in the "Branches" category. As the deploy action force pushes the branch, allowing force pushes will be necessary (second to last option "Allow force pushes").

### Commits

<details><summary><b>Move site build artifacts to separate site branch</b></summary>
<br>

Adjusts the deploy action to create a new orphan branch 'publish'
containing only the site build artifacts and site configuration files in
the root directory. This branch is then force-pushed to the repo,
replacing the previous site build.

This approach avoids having to include the site artifacts in the master
branch, reducing the repository size and avoiding including "deploy"
commits in the main history.

Adjusts '.asf.yaml' to match the new setup. Changes the branch id to
'publish'. Drops the 'staging' configuration as it reportedly does not
function correctly. Furthermore, the current content of the 'staging'
branch is no longer deployable with the new setup as it still uses the
old site deploy scheme.

Removes the '.htaccess' configuration as the redirection is no longer
necessary now that the resources are hosted in the root directory.

</details>