### PR TITLE
Adjust GitHub conf after site migration

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -12,3 +12,9 @@ github:
     - orm
     - apache
     - java
+
+  # Set up branch protection for site publishing branch to avoid accidental deletion
+  # Force-pushes are still necessary as they are used to deploy new versions of the site
+  protected_branches:
+    publish:
+      allow_force_pushes: true


### PR DESCRIPTION
This PR adjusts some of the GitHub repo settings that are accessible through the `.asf.yaml` file as specified in https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#git.asf.yamlfeatures-GitHubsettings.

In particular, this PR sets up branch protection for the `publish` branch, ensuring that it can't be deleted. This was done to avoid accidental deletions of the branch which could potentially break the website deployment.