### PR TITLE
Adjust deploy workflow to preserve history

### DIFF
--- a/.asf.yaml.publish
+++ b/.asf.yaml.publish
@@ -3,4 +3,4 @@
 # This file is only used on the site publishing branch
 publish:
   whoami:  publish
-  subdir:  jdo
+  subdir:  content/jdo

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,4 +1,8 @@
 # Builds and deploys the site if the build was successful
+#
+# This job builds the website and deploys the build artifacts to the 'content' directory
+# Any additional files that are not part of the site build but should be published (e.g. website configuration files) must be handled explicitly
+# See step "Move additional resources to build directory" and sub-steps "Dropping old site resources" and "Adding new site configuration" of the 'publish' step
 name: Build & Deploy Site
 
 # Conditions necessary to trigger a build
@@ -17,6 +21,8 @@ on:
       - 'src/main/asciidoc/**'
       - 'src/main/template/**'
       - '.asf.yaml.publish'
+      - '.htaccess'
+
 
 jobs:
   build:
@@ -28,8 +34,10 @@ jobs:
         with:
           fetch-depth: 1
 
+
       - name: Build Site
         run: mvn clean compile
+
 
       # Determines the short sha of the commit that triggered the build
       - name: Determine Short SHA
@@ -39,6 +47,7 @@ jobs:
           short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
           echo "::set-output name=short_sha::$short_sha"
         shell: 'bash'
+
 
       # Determines the author data of the HEAD commit
       # Sets up the author data to be used for the site deploy commit
@@ -55,28 +64,62 @@ jobs:
           git config user.email $author_email
         shell: 'bash'
 
-      # Publishes the site build results to a separate orphan branch
+
+      # Adds additional configuration files that are supposed to be included in the page deploy to the build directory
       #
-      # Creates and checks out a new orphan branch
-      # Creates a single commit containing only the site build artifacts and site configuration files located in the root directory
+      # This ensures that such files are preserved when checking out the publish branch
+      - name: Add additional resources to build directory
+        if: success()
+        run: |
+          cp -v .asf.yaml.publish target/site/.asf.yaml
+          cp -v .htaccess target/site/
+
+
+      # Publishes the site build results to a separate branch
+      #
+      # Checks out the site branch
+      # Replaces the site configuration files and site build artifact with the ones set up in the previous step
+      # Creates a new commit containing the new site build artifacts and site configuration files
       # The commit is created with the author data set up in the previous step
-      # Force-pushes the created branch, overwriting the previously published site build
+      # Pushes the site branch
       - name: Publish site branch
         if: success()
         run: |
           branch_name="publish"
 
-          echo "Creating orphan branch"
-          git checkout --orphan $branch_name
+          echo "Checking out site branch"
+          git fetch origin $branch_name
+          git checkout -b $branch_name origin/$branch_name
           echo
 
-          echo "Dropping content other than site data"
-          git reset
-          rm .gitignore
-          git add .asf.yaml.publish target/site
-          git clean -df
-          git mv target/site/* ./
-          git mv .asf.yaml.publish .asf.yaml
+          # Drops all existing files and folders except the base folder and the resources excluded by the regex
+          # This ensures that old configuration files that were removed on the master will be removed from the site branch as well
+          # Additional resources to exclude can be added by modifying the regex or adding new regex by using "-a -not -regex '...'"
+          echo "Dropping old site resources"
+          find . \
+            -mindepth 1 -regextype posix-extended \
+            -not -regex '^\./(target|.git)(/.*)?$' \
+            -delete -print
+          echo
+
+          echo "Adding new site configuration"
+          mv -v target/site/.asf.yaml ./
+          mv -v target/site/.htaccess ./
+          echo
+
+          echo "Adding new site build"
+          mkdir -v content
+          mv -v target/site/* content/
+          echo
+
+          # Explicitly removes build dir
+          # This checks whether there are any remaining resources that were not moved to the correct location
+          echo "Removing build dir"
+          rmdir -v -p target/site
+          echo
+
+          echo "Staging new content"
+          git add .
           echo
 
           echo "Committing changes"
@@ -84,5 +127,5 @@ jobs:
           echo
 
           echo "Pushing site branch"
-          git push -f origin $branch_name
+          git push origin $branch_name
         shell: 'bash'

--- a/.github/workflows/recreate-site-branch.yml
+++ b/.github/workflows/recreate-site-branch.yml
@@ -1,0 +1,89 @@
+# Recreates the orphan site branch
+#
+# This workflow is set up as a fallback in cases where the site branch has been deleted
+# The workflow to automatically publish the site after a push to the master relies on there already being a functioning site branch
+# This will not cause the website to be published; another push to the site branch (e.g. thought the deploy workflow) is necessary for this
+name: Recreate Site Branch - ONLY USE IF SITE BRANCH GOT DELETED
+
+# Conditions necessary to trigger a build
+#
+# Can only be triggered manually
+on:
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    name: Build & Deploy Site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 1
+
+
+      - name: Build Site
+        run: mvn clean compile
+
+
+      # Determines the short sha of the commit that triggered the build
+      - name: Determine Short SHA
+        if: success()
+        id: short-sha
+        run: |
+          short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
+          echo "::set-output name=short_sha::$short_sha"
+        shell: 'bash'
+
+
+      # Determines the author data of the HEAD commit
+      # Sets up the author data to be used for the site deploy commit
+      - name: Determine HEAD Commit Author Data
+        if: success()
+        id: author-data
+        run: |
+          echo "Reading author data"
+          author_name=$(git log -1 --format='%aN' HEAD)
+          author_email=$(git log -1 --format='%aE' HEAD)
+
+          echo "Setting up author data to use for deploy commit"
+          git config user.name $author_name
+          git config user.email $author_email
+        shell: 'bash'
+
+
+      # Publishes the site build results to a separate orphan branch
+      #
+      # Creates and checks out a new orphan branch
+      # Creates a single commit containing only the site build artifacts and site configuration files located in the root directory
+      # The commit is created with the author data set up in the previous step
+      # Force-pushes the created branch, overwriting the previously published site build
+      - name: Publish site branch
+        if: success()
+        run: |
+          branch_name="publish"
+
+          echo "Creating orphan branch"
+          git checkout --orphan $branch_name
+          echo
+
+          echo "Dropping content other than site data"
+          git reset
+          rm .gitignore
+          git add target/site
+          git add .asf.yaml.publish .htaccess
+          git clean -df
+          mkdir -v content
+          git mv target/site/* content/
+          git mv .asf.yaml.publish .asf.yaml
+          echo
+
+          echo "Committing changes"
+          git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.short_sha }}"
+          echo
+
+          echo "Pushing site branch"
+          git push -f origin $branch_name
+        shell: 'bash'

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteBase /jdo/
+RewriteRule ^(?!content/)(.*)$ content/$1


### PR DESCRIPTION
Adds the necessary configuration to host the website in the `content` directory. Adjusts the deploy workflow match the new layout and to preserver the site branch history. Also introduces a recovery workflow to recreate a stable base state for the site branch in case it ever gets deleted or corrupted. This recovery is necessary as the new deploy action can't function with an existing site branch that is in the expected state.

While this solution is less elegant than I would have liked, adjusting the deploy action to also handle a missing or corrupted site branch would have required a lot of additional work and would have most likely increased the size of the workflow considerably, thereby making it harder to understand.

The results of the new build action can be observed in my fork. I reset the `publish` branch using the new recovery workflow (to check whether it actually works and clean up previous tests with the new deploy workflow): [workflow runs](https://github.com/tobous/db-jdo-site/actions?query=workflow%3A%22Recreate+Site+Branch+-+ONLY+USE+IF+SITE+BRANCH+GOT+DELETED%22).
Afterwards, I pushed a minor change to the master to trigger the build:  [workflow runs](https://github.com/tobous/db-jdo-site/actions?query=workflow%3A%22Build+%26+Deploy+Site%22), [resulting `publish` branch](https://github.com/tobous/db-jdo-site/tree/publish).
As you can see, the workflow successfully deployed the new build artifacts while preserving the history.

How well the history is preserved as changes instead of replacements is entirely dependent on the internal git logic. The workflow simply deletes all existing site artifacts, replaces them with the new build artifacts and commits the results. But, as the build artifacts were committed the same way when they were still being kept as part of the master, this should not matter much.

### Commits

<details><summary><b>Adjust hosting configuration to match new setup</b></summary>
<br>

Adjusts the publishing '.asf.yaml' configuration to use 'content/jdo' as
the subdir.

Adds '.htaccess', setting up URL forwarding from 'db.apache.org/jdo/*'
to 'db.apache.org/content/jdo/*'. This was done to act as if the website
were hosted under 'jdo' directly.

</details>

<details><summary><b>Adjust site build workflow to preserve build artifact history</b></summary>
<br>

Adjusts the workflow building and publishing the website to the site
branch to preserve the history of the site branch.

This was done to avoid issues with the Apache backend caused by
force-pushing the new build results to an orphan branch every time.

This new behavior is a bit more brittle than the old one as it relies on
the current state of the site branch. The action will fails if the site
branch is not already present. Additionally, it might also fail if the
branch is in an unexpected state. But, as the action removes all
existing resources, this should be unlikely.

To resolve any issues caused by a missing or corrupted site branch, a
future commit will introduce a recovery workflow that can be used to
manually return the site branch to a usable base state.

</details>

<details><summary><b>Add recovery workflow to recreate the site branch</b></summary>
<br>

Adds a workflow to recreate the site branch in case it ever gets deleted
on accident or becomes corrupted.

The new workflow to automatically deploy the site relies on there being
a functioning site branch. This workflow offers an recovery option to
recreate a stable version of the site branch with which the deploy
workflow can function.

The workflow does not listen for any events on the repository. It can
only be triggered manually. To do so, go to the "Actions" section of the
GitHub page for the repository and select the action from the menu. At
the top of the list of past workflow runs is a blue bar offering the
option to "Run workflow". Select the option and press the green button
"Run workflow".

When running the workflow, the default selection to run it on the master
branch should not be changed. Even though the workflow is explicitly
configured to check out the master branch, running the action on a
different branch might still have other unintended side effects.

</details>