### PR TITLE
Clean up deploy actions

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,6 +28,9 @@ jobs:
   build:
     name: Build & Deploy Site
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
     env:
       # The name of the branch used to publish the website build artifacts
@@ -51,7 +54,6 @@ jobs:
         run: |
           short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
           echo "::set-output name=SHORT_SHA::$short_sha"
-        shell: 'bash'
 
 
       # Determines the author data of the HEAD commit
@@ -67,7 +69,6 @@ jobs:
           echo "Setting up author data to use for deploy commit"
           git config user.name $author_name
           git config user.email $author_email
-        shell: 'bash'
 
 
       # Adds additional configuration files that are supposed to be included in the page deploy to the build directory
@@ -131,4 +132,3 @@ jobs:
 
           echo "Pushing site branch"
           git push origin ${{ env.BRANCH_NAME }}
-        shell: 'bash'

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -50,7 +50,7 @@ jobs:
         id: short-sha
         run: |
           short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
-          echo "::set-output name=short_sha::$short_sha"
+          echo "::set-output name=SHORT_SHA::$short_sha"
         shell: 'bash'
 
 
@@ -126,7 +126,7 @@ jobs:
           echo
 
           echo "Committing changes"
-          git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.short_sha }}"
+          git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.SHORT_SHA }}"
           echo
 
           echo "Pushing site branch"

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -119,7 +119,7 @@ jobs:
           echo
 
           echo "Staging new content"
-          git add .
+          git add -v -A
           echo
 
           echo "Committing changes"

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,6 +28,11 @@ jobs:
   build:
     name: Build & Deploy Site
     runs-on: ubuntu-latest
+
+    env:
+      # The name of the branch used to publish the website build artifacts
+      BRANCH_NAME: publish
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,11 +90,9 @@ jobs:
       - name: Publish site branch
         if: success()
         run: |
-          branch_name="publish"
-
           echo "Checking out site branch"
-          git fetch origin $branch_name
-          git checkout -b $branch_name origin/$branch_name
+          git fetch origin ${{ env.BRANCH_NAME }}
+          git checkout -b ${{ env.BRANCH_NAME }} origin/${{ env.BRANCH_NAME }}
           echo
 
           # Drops all existing files and folders except the base folder and the resources excluded by the regex
@@ -127,5 +130,5 @@ jobs:
           echo
 
           echo "Pushing site branch"
-          git push origin $branch_name
+          git push origin ${{ env.BRANCH_NAME }}
         shell: 'bash'

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -44,7 +44,8 @@ jobs:
 
 
       - name: Build Site
-        run: mvn clean compile
+        run: |
+          mvn clean compile
 
 
       # Determines the short sha of the commit that triggered the build
@@ -74,54 +75,60 @@ jobs:
       # Adds additional configuration files that are supposed to be included in the page deploy to the build directory
       #
       # This ensures that such files are preserved when checking out the publish branch
-      - name: Add additional resources to build directory
+      - name: Add Additional Resources to Build Directory
         if: success()
         run: |
           cp -v .asf.yaml.publish target/site/.asf.yaml
           cp -v .htaccess target/site/
 
 
-      # Publishes the site build results to a separate branch
-      #
-      # Checks out the site branch
-      # Replaces the site configuration files and site build artifact with the ones set up in the previous step
-      # Creates a new commit containing the new site build artifacts and site configuration files
-      # The commit is created with the author data set up in the previous step
-      # Pushes the site branch
-      - name: Publish site branch
+      - name: Check Out Site Branch
         if: success()
         run: |
-          echo "Checking out site branch"
           git fetch origin ${{ env.BRANCH_NAME }}
           git checkout -b ${{ env.BRANCH_NAME }} origin/${{ env.BRANCH_NAME }}
-          echo
 
-          # Drops all existing files and folders except the base folder and the resources excluded by the regex
-          # This ensures that old configuration files that were removed on the master will be removed from the site branch as well
-          # Additional resources to exclude can be added by modifying the regex or adding new regex by using "-a -not -regex '...'"
-          echo "Dropping old site resources"
+
+      # Drops all existing files and folders except the base folder and the resources excluded by the regex
+      # This ensures that old configuration files that were removed on the master will be removed from the site branch as well
+      # Additional resources to exclude can be added by modifying the regex or adding new regex by using "-a -not -regex '...'"
+      - name: Drop Old Site Resources
+        if: success()
+        run: |
           find . \
             -mindepth 1 -regextype posix-extended \
             -not -regex '^\./(target|.git)(/.*)?$' \
             -delete -print
-          echo
 
-          echo "Adding new site configuration"
+
+      # Moves additional configuration files that were added to the build directory to their target directory
+      # In general, this should move all resources touched in the step 'Add additional resources to build directory'
+      - name: Add New Site Configuration
+        if: success()
+        run: |
           mv -v target/site/.asf.yaml ./
           mv -v target/site/.htaccess ./
-          echo
 
-          echo "Adding new site build"
+
+      # Moves the new site resources from the build directory to the content directory
+      - name: Add New Site Resources
+        if: success()
+        run: |
           mkdir -v content
           mv -v target/site/* content/
-          echo
 
           # Explicitly removes build dir
           # This checks whether there are any remaining resources that were not moved to the correct location
+          echo
           echo "Removing build dir"
           rmdir -v -p target/site
-          echo
 
+
+      # Publishes the build results
+      # Does nothing if there is nothing to publish
+      - name: Publish Results
+        if: success()
+        run: |
           echo "Staging new content"
           git add -v -A
           echo

--- a/.github/workflows/recreate-site-branch.yml
+++ b/.github/workflows/recreate-site-branch.yml
@@ -33,7 +33,8 @@ jobs:
 
 
       - name: Build Site
-        run: mvn clean compile
+        run: |
+          mvn clean compile
 
 
       # Determines the short sha of the commit that triggered the build
@@ -60,33 +61,39 @@ jobs:
           git config user.email $author_email
 
 
-      # Publishes the site build results to a separate orphan branch
-      #
-      # Creates and checks out a new orphan branch
-      # Creates a single commit containing only the site build artifacts and site configuration files located in the root directory
-      # The commit is created with the author data set up in the previous step
-      # Force-pushes the created branch, overwriting the previously published site build
-      - name: Publish site branch
+      # Creates and checks out a new orphan branch used to publish the site
+      - name: Create Orphan Site Branch
         if: success()
         run: |
-          echo "Creating orphan branch"
           git checkout --orphan ${{ env.BRANCH_NAME }}
-          echo
 
-          echo "Dropping content other than site data"
+
+      # Drops all content other than the site data from the workspace
+      # This creates a minimal state that only contains the website build results
+      - name: Drop Content Other Than Site Data
+        if: success()
+        run: |
           git reset
           rm .gitignore
           git add target/site
           git add .asf.yaml.publish .htaccess
           git clean -df
+
+
+      # Moves the site content and site configuration to the correct location
+      - name: Move Content and Site Configuration
+        if: success()
+        run: |
           mkdir -v content
-          git mv target/site/* content/
-          git mv .asf.yaml.publish .asf.yaml
-          echo
+          git mv -v target/site/* content/
+          git mv -v .asf.yaml.publish .asf.yaml
 
-          echo "Committing changes"
+
+      # Creates a single commit containing only the site build artifacts and site configuration files
+      # The commit is created with the author data set up in the previous step
+      # Force-pushes the created branch, overwriting the previously published site build
+      - name: Publish Results
+        if: success()
+        run: |
           git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.SHORT_SHA }}"
-          echo
-
-          echo "Pushing site branch"
           git push -f origin ${{ env.BRANCH_NAME }}

--- a/.github/workflows/recreate-site-branch.yml
+++ b/.github/workflows/recreate-site-branch.yml
@@ -16,6 +16,9 @@ jobs:
   build:
     name: Build & Deploy Site
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
     env:
       # The name of the branch used to publish the website build artifacts
@@ -40,7 +43,6 @@ jobs:
         run: |
           short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
           echo "::set-output name=SHORT_SHA::$short_sha"
-        shell: 'bash'
 
 
       # Determines the author data of the HEAD commit
@@ -56,7 +58,6 @@ jobs:
           echo "Setting up author data to use for deploy commit"
           git config user.name $author_name
           git config user.email $author_email
-        shell: 'bash'
 
 
       # Publishes the site build results to a separate orphan branch
@@ -89,4 +90,3 @@ jobs:
 
           echo "Pushing site branch"
           git push -f origin ${{ env.BRANCH_NAME }}
-        shell: 'bash'

--- a/.github/workflows/recreate-site-branch.yml
+++ b/.github/workflows/recreate-site-branch.yml
@@ -39,7 +39,7 @@ jobs:
         id: short-sha
         run: |
           short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
-          echo "::set-output name=short_sha::$short_sha"
+          echo "::set-output name=SHORT_SHA::$short_sha"
         shell: 'bash'
 
 
@@ -84,7 +84,7 @@ jobs:
           echo
 
           echo "Committing changes"
-          git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.short_sha }}"
+          git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.SHORT_SHA }}"
           echo
 
           echo "Pushing site branch"

--- a/.github/workflows/recreate-site-branch.yml
+++ b/.github/workflows/recreate-site-branch.yml
@@ -16,6 +16,11 @@ jobs:
   build:
     name: Build & Deploy Site
     runs-on: ubuntu-latest
+
+    env:
+      # The name of the branch used to publish the website build artifacts
+      BRANCH_NAME: publish
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -63,10 +68,8 @@ jobs:
       - name: Publish site branch
         if: success()
         run: |
-          branch_name="publish"
-
           echo "Creating orphan branch"
-          git checkout --orphan $branch_name
+          git checkout --orphan ${{ env.BRANCH_NAME }}
           echo
 
           echo "Dropping content other than site data"
@@ -85,5 +88,5 @@ jobs:
           echo
 
           echo "Pushing site branch"
-          git push -f origin $branch_name
+          git push -f origin ${{ env.BRANCH_NAME }}
         shell: 'bash'


### PR DESCRIPTION
Cleans up the existing GitHub actions. Each change is described in more details in the corresponding commit message. I would suggest looking at the changes commit by commit instead of looking at the entire diff all at once.