### PR TITLE
Only try to publish results if there are any changes

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -124,15 +124,30 @@ jobs:
           rmdir -v -p target/site
 
 
+      - name: Stage Changes
+        id: stage-changes
+        if: success()
+        run: |
+          git add -v -A
+
+          if $(git diff -s --cached --exit-code)
+            then
+              # nothing staged
+              echo "Nothing to commit"
+              has_staged_changes=false
+            else
+              # something staged
+              has_staged_changes=true
+          fi
+
+          echo "::set-output name=HAS_STAGED_CHANGES::$has_staged_changes"
+
+
       # Publishes the build results
       # Does nothing if there is nothing to publish
       - name: Publish Results
-        if: success()
+        if: success() && steps.stage-changes.outputs.HAS_STAGED_CHANGES == 'true'
         run: |
-          echo "Staging new content"
-          git add -v -A
-          echo
-
           echo "Committing changes"
           git commit -m "Auto-deploy site for commit ${{ steps.short-sha.outputs.SHORT_SHA }}"
           echo


### PR DESCRIPTION
Adjusts the deploy action to only try to commit and push if there are
any staged changes. This avoids the action "failing" if there is nothing
to commit.

This explicitly fixes the use-case of re-triggering an already successful action run. When there is nothing to commit, the "Publish Results" step is skipped, which is also shown in the action log. This makes it immediately apparent that the job ran successfully but did not deploy any changes to the site branch (see [example run](https://github.com/tobous/db-jdo-site/runs/1864040848)).