### PR TITLE
Set notification settings in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,3 +18,9 @@ github:
   protected_branches:
     publish:
       allow_force_pushes: true
+
+notifications:
+  commits:      jdo-commits@db.apache.org
+  issues:       jdo-dev@db.apache.org
+  pullrequests: jdo-dev@db.apache.org
+  jira_options: link label


### PR DESCRIPTION
Adds specific notification settings in the asf.yaml configuration.

Diverts messages regarding new commits being pushed to the 'jdo-commits'
mailing list to avoid clogging up 'jdo-dev'. The notifications for
pull-requests and issues still go to 'jdo-dev'.

Adds the preexisting jira linking options to the configurations. With
the current configuration, the label 'pull-request-available' and a link
to the pull-request/issue is automatically added to any Jira ticket that
is referenced in the pull-request/issue name. See wiki for more details.

The current configuration can be viewed [here](https://gitbox.apache.org/schemes.cgi?db-jdo-site). With this change, the settings for the site repo will match the [notification settings for the main repo](https://gitbox.apache.org/schemes.cgi?db-jdo).