### PR TITLE
Mention automatic JIRA linking as part of the "Get Involved" page

### DIFF
--- a/src/main/asciidoc/get-involved.adoc
+++ b/src/main/asciidoc/get-involved.adoc
@@ -18,12 +18,16 @@ The default way of providing contributions to this project is through our GitHub
 (link:https://github.com/apache/db-jdo[JDO repo], link:https://github.com/apache/db-jdo-site[website repo]).
 We are following the default link:https://guides.github.com/introduction/flow/[GitHub workflow] using link:https://guides.github.com/activities/forking/[forks].
 
+If a pull request is related to an existing https://issues.apache.org/jira/secure/BrowseProject.jspa?id=10630[JDO JIRA] ticket, you can include a reference to the ticket in the title using the format `+[JDO-1234]+`.
+This will automatically create a reference to the pull request in the ticket.
+Please also include a link to the referenced JIRA ticket in the pull request message.
+
 More information on how to access the project source code is available link:source-code.html[here].
 
 
 === Reporting Bugs
 
-Bugs and other issues can be posted on the project http://issues.apache.org/jira/secure/BrowseProject.jspa?id=10630[JIRA].
+Bugs and other issues can be posted on the project https://issues.apache.org/jira/secure/BrowseProject.jspa?id=10630[JIRA].
 
 
 === Contacting Us


### PR DESCRIPTION
Mentions the capability to automatically referencing a pull request in a
JIRA ticket by including a reference to the ticket in the pull request
title in the "Get Involved" section.

The wording was chosen carefully not to imply that this would actually
link the state of the two. As far as I can tell, merging the pull
request will not have any influence on the state of the referenced
ticket. If this is actually the case, the wording should be adjusted to
reflect the behavior.

This functionality is described in the [`.asf.yaml` wiki](https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-Jiranotificationoptions).