### PR TITLE
Use icons with highest resolution available for website

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -5,7 +5,7 @@
 :grid: cols
 
 [[index]]
-image:images/JDOx100.png[float="left"]
+image:images/JDOx150.png[logo,100,100,float="left"]
 image:images/jdo_text.png[float="right"]
 
 '''''

--- a/src/main/template/document.html.erb
+++ b/src/main/template/document.html.erb
@@ -13,7 +13,7 @@
 
     <title><%= doctitle(:sanitize => true) || (attr 'untitled-label') %></title>
 
-    <link rel="icon" type="image/png" href="<%= (attr :_basedir) %>images/JDO_32x32.png"/>
+    <link rel="icon" type="image/png" href="<%= (attr :_basedir) %>images/JDOx150.png"/>
 
     <!--
         Apache JDO Documentation Template
@@ -108,7 +108,7 @@
             </button>
             <!-- 'style' added to align image with navbar. FIX THIS -->
             <a class="navbar-brand" href="https://db.apache.org/jdo/">
-                <img style="margin-top: -12px;" alt="Brand" src="<%= (attr :_basedir) %>images/JDO_44x44.png"/>
+                <img style="margin-top: -12px;" alt="Brand" width="45.5" height="45.5" src="<%= (attr :_basedir) %>images/JDOx150.png"/>
             </a>
             <!-- TODO Any way to abstract the version from Maven? -->
             <a class="navbar-brand" href="<%= (attr :_basedir) %>index.html">Apache JDO</a>


### PR DESCRIPTION
Adjusts the website to use the 150x150 version of the JDO logo instead
of smaller ones. Sets the scaling manually to keep the previous size
when using the larger image.

Adjusts the image size of the header icon to better fit the bar and
create an even spacing with the default layout.