### PR TITLE
Simplify workflow branch rule

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -8,13 +8,11 @@ name: Build & Deploy Site
 # Conditions necessary to trigger a build
 on:
   push:
-    # Ignore pushes on all branches by default
-    # Branches that should trigger a build must be explicitly excluded from the ignore using '!BRANCH_NAME'
+    # Only run for pushes to the following branches
     #
-    # Excluding the branch that is pushed by this action will lead to an infinite loop
-    branches-ignore:
-      - '**'
-      - '!master'
+    # Including the branch that is pushed by this action will lead to an infinite loop
+    branches:
+      - 'master'
 
     # Only build if a file in one of these paths has been changed
     paths:


### PR DESCRIPTION
Simplifies the deploy workflow branch rule by switching to specifying
which branches to run on.

I previously thought that 'branch' and 'path' rules were compared with
an OR operator. From my new tests, this does not seem to be the case.
Instead, they are compared with the AND operator, allowing for this
simplified configuration.