### PR TITLE
Add site build workflow for pull requests

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,27 @@
+# Builds the site
+#
+# This job builds the website for pull requests to ensure that the PR does not break the build
+name: Build Site
+
+# Conditions necessary to trigger a build
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Build Site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+
+      - name: Build Site
+        run: |
+          mvn clean compile


### PR DESCRIPTION
Adds a simple site build workflow running only for pull requests. The
job allows us to check whether a PR breaks the site build before merging
it.