### PR TITLE
Move copy-resources from compile to prepare-package lifecycle phase

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build Site
         run: |
-          mvn clean compile
+          mvn clean package
 
 
       # Determines the short sha of the commit that triggered the build

--- a/.github/workflows/recreate-site-branch.yml
+++ b/.github/workflows/recreate-site-branch.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build Site
         run: |
-          mvn clean compile
+          mvn clean package
 
 
       # Determines the short sha of the commit that triggered the build

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                 <executions>
                     <execution>
                         <id>copy-resources</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>


### PR DESCRIPTION
- Moved the execution of copy-resources from compile to prepare-package phase.
- Replaced 'mvn clean compile' by 'mvn clean package' in the github workflows deploy-site and recreate-site-branch