### PR TITLE
JDO-789: Cleanup jdo-site pom

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -117,9 +117,23 @@ jobs:
 
           # Explicitly removes build dir
           # This checks whether there are any remaining resources that were not moved to the correct location
+          # Drops the rest of the resources in the target directory if there are any
           echo
-          echo "Removing build dir"
-          rmdir -v -p target/site
+          echo "Removing site build directory"
+
+          if rmdir -v target/site
+            then
+              echo
+              echo "Removing remaining build directories"
+              rm -r -v target
+
+            else
+              echo
+              echo "Failed due to resources remaining in site build directory:"
+              tree target/site
+
+              exit 1
+          fi
 
 
       - name: Stage Changes

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,11 @@
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
         <version>23</version>
-        <relativePath></relativePath>
     </parent>
     
     <groupId>org.apache.jdo</groupId>
     <artifactId>jdo-site</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache JDO Site</name>

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
 Java model abstraction of persistence, developed as Java Specification 
 Requests (JSR 12 and 243) under the auspices of the Java Community Process.
 This repository contains the sources for the Apache DB JDO website</description>
-    <url>http://db.apache.org/jdo</url>
+    <url>https://db.apache.org/jdo</url>
     <inceptionYear>2019</inceptionYear>
     <organization>
         <name>Apache Software Foundation</name>
-        <url>http://www.apache.org</url>
+        <url>https://www.apache.org</url>
     </organization>
 
     <scm>
@@ -65,7 +65,7 @@ This repository contains the sources for the Apache DB JDO website</description>
                         <baseDir>${project.basedir}</baseDir>
                         <!-- Attributes common to all output formats -->
                         <attributes>
-                            <endpoint-url>http://db.apache.org/jdo</endpoint-url>
+                            <endpoint-url>https://db.apache.org/jdo</endpoint-url>
                             <sourcedir>${project.build.sourceDirectory}</sourcedir>
                             <project-version>${project.version}</project-version>
                         </attributes>

--- a/pom.xml
+++ b/pom.xml
@@ -1,34 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.jdo.asciidoc</groupId>
-  <artifactId>jdo-asciidoc</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+    <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>23</version>
+        <relativePath></relativePath>
+    </parent>
+    
+    <groupId>org.apache.jdo</groupId>
+    <artifactId>jdo-site</artifactId>
+    <version>3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Apache JDO Asciidoc</name>
-    <description>Apache JDO Asciidoc</description>
-    <url>http://www.apache.org/jdo</url>
-    <inceptionYear>2019</inceptionYear>
 
-    <repositories>
-        <repository>
-            <id>Apache_M2_Nightly</id>
-            <url>http://repository.apache.org/snapshots/</url>
-        </repository>
-    </repositories>
+    <name>Apache JDO Site</name>
+    <description>The Java Data Objects (JDO) API is a standard interface-based 
+Java model abstraction of persistence, developed as Java Specification 
+Requests (JSR 12 and 243) under the auspices of the Java Community Process.
+This repository contains the sources for the Apache DB JDO website</description>
+    <url>http://db.apache.org/jdo</url>
+    <inceptionYear>2019</inceptionYear>
+    <organization>
+        <name>Apache Software Foundation</name>
+        <url>http://www.apache.org</url>
+    </organization>
+
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/db-jdo-site.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/db-jdo-site.git</developerConnection>
+        <url>https://gitbox.apache.org/repos/asf?p=db-jdo-site.git</url>
+    </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.11</asciidoctorj.pdf.version>
-        <asciidoctorj.version>1.5.4.1</asciidoctorj.version>
-        <!-- asciidoctorj.diagram.version>1.5.0</asciidoctorj.diagram.version-->
-        <!--incode-asciidoctor-extension-monotree.version>0.0.2</incode-asciidoctor-extension-monotree.version-->
-        <!--incode-asciidoctor-extension-improvethisdoc.version>0.0.1</incode-asciidoctor-extension-improvethisdoc.version-->
-        <jruby.version>1.7.26</jruby.version>
-        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-
+        <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
+        <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <build.dir>${project.basedir}/target/site</build.dir>
     </properties>
 
@@ -39,54 +62,14 @@
                     <groupId>org.asciidoctor</groupId>
                     <artifactId>asciidoctor-maven-plugin</artifactId>
                     <version>${asciidoctor.maven.plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctorj-pdf</artifactId>
-                            <version>${asciidoctorj.pdf.version}</version>
-                        </dependency>
-                        <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                        <dependency>
-                            <groupId>org.jruby</groupId>
-                            <artifactId>jruby-complete</artifactId>
-                            <version>${jruby.version}</version>
-                        </dependency>
-                        <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
-                        <dependency>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctorj</artifactId>
-                            <version>${asciidoctorj.version}</version>
-                        </dependency>
-                        <!-- dependency>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctorj-diagram</artifactId>
-                            <version>${asciidoctorj.diagram.version}</version>
-                        </dependency-->
-                        <!-- dependency>
-                            <groupId>org.incode.asciidoctor.monotree</groupId>
-                            <artifactId>incode-asciidoctor-extension-monotree</artifactId>
-                            <version>${incode-asciidoctor-extension-monotree.version}</version>
-                        </dependency-->
-                        <!-- dependency>
-                            <groupId>org.incode.asciidoctor.improvethisdoc</groupId>
-                            <artifactId>incode-asciidoctor-extension-improvethisdoc</artifactId>
-                            <version>${incode-asciidoctor-extension-improvethisdoc.version}</version>
-                        </dependency-->
-                    </dependencies>
                     <configuration>
-                        <!-- If you set baseDir to ${project.basedir}, top-level includes are resolved relative to the project root -->
-                        <!--
                         <baseDir>${project.basedir}</baseDir>
-                        -->
                         <!-- Attributes common to all output formats -->
                         <attributes>
                             <endpoint-url>http://db.apache.org/jdo</endpoint-url>
                             <sourcedir>${project.build.sourceDirectory}</sourcedir>
                             <project-version>${project.version}</project-version>
                         </attributes>
-                        <!-- requires>
-                            <require>asciidoctor-diagram</require>
-                        </requires-->
                     </configuration>
                 </plugin>
             </plugins>
@@ -120,7 +103,7 @@
                 </executions>
             </plugin>
         </plugins>
-        
+
     </build>
 
     <profiles>
@@ -144,21 +127,17 @@
                                     <goal>process-asciidoc</goal>
                                 </goals>
                                 <configuration>
-                                    <backend>html5</backend>
-
                                     <sourceDirectory>src/main/asciidoc/</sourceDirectory>
                                     <outputDirectory>${project.reporting.outputDirectory}/</outputDirectory>
-
-                                    <sourceHighlighter>coderay</sourceHighlighter>
-                                    <templateDir>src/main/template</templateDir>
+                                    <templateDirs>
+                                        <templateDir>src/main/template</templateDir>
+                                    </templateDirs>
                                     <eruby>erb</eruby>
                                     <preserveDirectories>true</preserveDirectories>
                                     <relativeBaseDir>true</relativeBaseDir>
-
                                     <attributes>
                                         <sourcedir>${project.build.sourceDirectory}</sourcedir>
-                                        <imagesdir/>
-                                        <toc>left</toc>
+                                        <source-highlighter>coderay</source-highlighter>
                                         <icons>font</icons>
                                         <version>${project.version}</version>
                                     </attributes>

--- a/src/main/template/document.html.erb
+++ b/src/main/template/document.html.erb
@@ -304,7 +304,7 @@
                           <a href="api31/apidocs/index.html" title="Latest Javadocs">Latest Javadocs</a>
           </div>
       </div>
-      <p class="text-center" style="margin-top:16px">&copy; 2005-2020 Apache Software Foundation. All Rights Reserved.</p>
+      <p class="text-center" style="margin-top:16px">&copy; 2005-2021 Apache Software Foundation. All Rights Reserved.</p>
   </div>
   </footer>
 <% end %>


### PR DESCRIPTION
Here are the updates of the pom.xml:
- Added Apache License
- Added Apache parent pom
- Changed groupId to org.apache.jdo (same as db-jdo)
- Changed artifactId to jdo-site
- Changed version to 3.2-SNAPSHOT (same as db-jdo)
- Changed name to Apache JDO Site
- Added description
- Fixed url
- Added organization
- Added scm block with gitbox url
- Updated dependency of asciidoctor maven plugin to most recent version 
- Removed commented out line

Please note the update to version 2 of asciidoctor maven plugin requires some configuration changes.
Also when converting glossary.adoc asciidoctor prints three info messages, which are false positive:
INFO: possible invalid reference: application-identity

I also updated the copyright notice in the template to include 2021 