### PR TITLE
Adjust branch protection to use previous name

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,7 +32,7 @@ github:
         strict: false
         # contexts are the names of checks that must pass
         contexts:
-          - build-site
+          - "Build Site"
 
     # rules for the 'publish' branch
     #


### PR DESCRIPTION
Adjusts the branch protection to use the previous name for the required
action. As this change will only apply after it was merged into master,
the name of the required action will be changed separately.