### PR TITLE
Revert "Fix branch protection"

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,7 +1,7 @@
 # Builds the site
 #
 # This job builds the website for pull requests to ensure that the PR does not break the build
-name: build-site
+name: Build Site
 
 # Conditions necessary to trigger a build
 on:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build-site:
+    name: Build Site
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This reverts commit e5def6b2a20602562f346b14eb5d3f01d2b8a735.

This fix was necessary to allow us to merge pull requests. Now that the
configuration has been updated, the nicer action name should be
restored.