### PR TITLE
Remove required GitHub actions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,9 +30,6 @@ github:
       required_status_checks:
         # strict means "Require branches to be up to date before merging".
         strict: false
-        # contexts are the names of checks that must pass
-        contexts:
-          - "Build Site"
 
     # rules for the 'publish' branch
     #


### PR DESCRIPTION
Remove required GitHub actions to allow directly pushing to 'master'.
Also prevent accidental desyncs when directly pushing to 'master'
through GitBox.